### PR TITLE
Isolate React 19 MFE from host React 18 share scope

### DIFF
--- a/host/src/bootstrap.tsx
+++ b/host/src/bootstrap.tsx
@@ -7,36 +7,12 @@ import App from "./App";
 // Host owns its own root
 createRoot(document.getElementById("host-root")!).render(<App />);
 
-// Mount React 18 remote via normal dynamic import (shares the host scope)
+// React 18 remote shares the host scope
 import("mfeA/mount").then(({ mount }) =>
   mount(document.getElementById("slot-a")!)
 );
 
-// Manually load mfeB so it can use its React 19 share scope
-(async () => {
-  const url = "http://localhost:3002/remoteEntry.js";
-
-  // Load remote container if not yet loaded
-  if (!(window as any).mfeB) {
-    await new Promise<void>((resolve, reject) => {
-      const s = document.createElement("script");
-      s.src = url;
-      s.async = true;
-      s.type = "text/javascript";
-      s.onload = () => resolve();
-      s.onerror = () => reject(new Error(`Failed to load ${url}`));
-      document.head.appendChild(s);
-    });
-  }
-
-  // Initialise the correct share scope for React 19
-  // @ts-ignore
-  await __webpack_init_sharing__("react19");
-  const container = (window as any).mfeB;
-  // @ts-ignore
-  await container.init(__webpack_share_scopes__["react19"]);
-
-  const factory = await container.get("./mount");
-  const { mount } = factory();
-  mount(document.getElementById("slot-b")!);
-})();
+// React 19 remote uses its own share scope configured in webpack
+import("mfeB/mount").then(({ mount }) =>
+  mount(document.getElementById("slot-b")!)
+);

--- a/host/src/bootstrap.tsx
+++ b/host/src/bootstrap.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-console.log('[host] React', (React as any).version);  // should log 18.x
+console.log("[host] React", (React as any).version); // should log 18.x
 
 import { createRoot } from "react-dom/client";
 import App from "./App";
@@ -7,11 +7,36 @@ import App from "./App";
 // Host owns its own root
 createRoot(document.getElementById("host-root")!).render(<App />);
 
-// ✅ Dynamic import remotes (lets MF init the share scope automatically)
-(async () => {
-  const { mount: mountA } = await import("mfeA/mount");
-  const { mount: mountB } = await import("mfeB/mount");
+// Mount React 18 remote via normal dynamic import (shares the host scope)
+import("mfeA/mount").then(({ mount }) =>
+  mount(document.getElementById("slot-a")!)
+);
 
-  mountA(document.getElementById("slot-a")!);
-  mountB(document.getElementById("slot-b")!);
+// Manually load mfeB so it can use its React 19 share scope
+(async () => {
+  const url = "http://localhost:3002/remoteEntry.js";
+
+  // Load remote container if not yet loaded
+  if (!(window as any).mfeB) {
+    await new Promise<void>((resolve, reject) => {
+      const s = document.createElement("script");
+      s.src = url;
+      s.async = true;
+      s.type = "text/javascript";
+      s.onload = () => resolve();
+      s.onerror = () => reject(new Error(`Failed to load ${url}`));
+      document.head.appendChild(s);
+    });
+  }
+
+  // Initialise the correct share scope for React 19
+  // @ts-ignore
+  await __webpack_init_sharing__("react19");
+  const container = (window as any).mfeB;
+  // @ts-ignore
+  await container.init(__webpack_share_scopes__["react19"]);
+
+  const factory = await container.get("./mount");
+  const { mount } = factory();
+  mount(document.getElementById("slot-b")!);
 })();

--- a/host/webpack.config.js
+++ b/host/webpack.config.js
@@ -23,7 +23,10 @@ module.exports = {
       name: 'host',
       remotes: {
         mfeA: 'mfeA@http://localhost:3001/remoteEntry.js',
-        mfeB: 'mfeB@http://localhost:3002/remoteEntry.js'
+        mfeB: {
+          external: 'mfeB@http://localhost:3002/remoteEntry.js',
+          shareScope: 'react19'
+        }
       },
       shareScope: 'react18',
       shared: {


### PR DESCRIPTION
## Summary
- manually load `mfeB` so it runs with its own React 19 share scope
- dynamically import `mfeA` as before, keeping it on React 18

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68bab447d628832fbf019be0dfa965f4