### PR TITLE
Add routing within micro frontends

### DIFF
--- a/host/src/App.tsx
+++ b/host/src/App.tsx
@@ -15,8 +15,8 @@ export default function App() {
       <Suspense fallback={<div>Loading…</div>}>
         <Routes>
           <Route path="/" element={<Home />} />
-          <Route path="/a" element={<MicroFrontend remote="mfeA" />} />
-          <Route path="/b" element={<MicroFrontend remote="mfeB" />} />
+          <Route path="/a/*" element={<MicroFrontend remote="mfeA" />} />
+          <Route path="/b/*" element={<MicroFrontend remote="mfeB" />} />
         </Routes>
       </Suspense>
     </BrowserRouter>

--- a/host/webpack.config.js
+++ b/host/webpack.config.js
@@ -31,7 +31,8 @@ module.exports = {
       shareScope: 'react18',
       shared: {
         react: { singleton: true, requiredVersion: '^18.3.1', eager: false, strictVersion: false },
-        'react-dom': { singleton: true, requiredVersion: '^18.3.1', eager: false, strictVersion: false }
+        'react-dom': { singleton: true, requiredVersion: '^18.3.1', eager: false, strictVersion: false },
+        'react-router-dom': { singleton: true, requiredVersion: '^7.8.2', eager: false, strictVersion: false }
       }
     }),
     new HtmlWebpackPlugin({ template: path.resolve(__dirname, 'public/index.html') })

--- a/mfe-a/package.json
+++ b/mfe-a/package.json
@@ -8,7 +8,8 @@
     },
     "dependencies": {
       "react": "^18.3.1",
-      "react-dom": "^18.3.1"
+      "react-dom": "^18.3.1",
+      "react-router-dom": "^7.8.2"
     },
     "devDependencies": {
       "@types/react": "^18.2.66",

--- a/mfe-a/src/AppA.tsx
+++ b/mfe-a/src/AppA.tsx
@@ -1,9 +1,20 @@
 import React from 'react';
+import { Link, Routes, Route } from 'react-router-dom';
+import PageOne from './PageOne';
+import PageTwo from './PageTwo';
+
 export default function AppA() {
   return (
     <div style={{ padding: 12, border: '1px dashed #aaa' }}>
       <strong>MFE A</strong>
-      <div>Rendered inside its own React root.</div>
+      <nav style={{ display: 'flex', gap: 8 }}>
+        <Link to="">One</Link>
+        <Link to="two">Two</Link>
+      </nav>
+      <Routes>
+        <Route index element={<PageOne />} />
+        <Route path="two" element={<PageTwo />} />
+      </Routes>
     </div>
   );
 }

--- a/mfe-a/src/PageOne.tsx
+++ b/mfe-a/src/PageOne.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+export default function PageOne() {
+  return <div>Page One from MFE A</div>;
+}

--- a/mfe-a/src/PageTwo.tsx
+++ b/mfe-a/src/PageTwo.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+export default function PageTwo() {
+  return <div>Second page inside MFE A</div>;
+}

--- a/mfe-a/webpack.config.js
+++ b/mfe-a/webpack.config.js
@@ -29,7 +29,8 @@ module.exports = {
       shareScope: 'react18',
       shared: {
         react: { singleton: true, requiredVersion: '^18.3.1', eager: false, strictVersion: false },
-        'react-dom': { singleton: true, requiredVersion: '^18.3.1', eager: false, strictVersion: false }
+        'react-dom': { singleton: true, requiredVersion: '^18.3.1', eager: false, strictVersion: false },
+        'react-router-dom': { singleton: true, requiredVersion: '^7.8.2', eager: false, strictVersion: false }
       }
     }),
     new HtmlWebpackPlugin({ template: path.resolve(__dirname, 'public/index.html') })

--- a/mfe-b/package.json
+++ b/mfe-b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.8.2"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/mfe-b/src/AppB.tsx
+++ b/mfe-b/src/AppB.tsx
@@ -1,9 +1,23 @@
 import React from 'react';
+import { MemoryRouter, Routes, Route, Link } from 'react-router-dom';
+import PageOne from './PageOne';
+import PageTwo from './PageTwo';
+
 export default function AppB() {
   return (
     <div style={{ padding: 12, border: '1px dashed #aaa' }}>
-      <strong>MFE B</strong>
-      <div>Rendered inside its own React root.</div>
+      <MemoryRouter>
+        <strong>MFE B</strong>
+        <nav style={{ display: 'flex', gap: 8 }}>
+          <Link to="/">One</Link>
+          <Link to="/two">Two</Link>
+        </nav>
+        <Routes>
+          <Route path="/" element={<PageOne />} />
+          <Route path="/two" element={<PageTwo />} />
+        </Routes>
+        <div>Rendered inside its own React root.</div>
+      </MemoryRouter>
     </div>
   );
 }

--- a/mfe-b/src/PageOne.tsx
+++ b/mfe-b/src/PageOne.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+export default function PageOne() {
+  return <div>Page One from MFE B</div>;
+}

--- a/mfe-b/src/PageTwo.tsx
+++ b/mfe-b/src/PageTwo.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+export default function PageTwo() {
+  return <div>Second page inside MFE B</div>;
+}

--- a/mfe-b/webpack.config.js
+++ b/mfe-b/webpack.config.js
@@ -25,7 +25,8 @@ module.exports = {
       shareScope: 'react19',
       shared: {
         react: { singleton: true, requiredVersion: '^19.0.0', eager: false, strictVersion: false },
-        'react-dom': { singleton: true, requiredVersion: '^19.0.0', eager: false, strictVersion: false }
+        'react-dom': { singleton: true, requiredVersion: '^19.0.0', eager: false, strictVersion: false },
+        'react-router-dom': { singleton: true, requiredVersion: '^7.8.2', eager: false, strictVersion: false }
       }
     }),
     new HtmlWebpackPlugin({ template: path.resolve(__dirname, 'public/index.html') })


### PR DESCRIPTION
## Summary
- enable nested routes in host for micro frontends
- add internal navigation to MFE A and MFE B
- share react-router-dom across host and MFEs

## Testing
- `yarn install` (fails: RequestError 403)
- `yarn build` (fails: package not in lockfile)


------
https://chatgpt.com/codex/tasks/task_e_68be818662f4832fab4740f271456d20