### PR TITLE
feat(mfe-b): add react-select fruit dropdown

### DIFF
--- a/mfe-b/package.json
+++ b/mfe-b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.8.2"
+    "react-router-dom": "^7.8.2",
+    "react-select": "^5.8.0"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/mfe-b/src/PageTwo.tsx
+++ b/mfe-b/src/PageTwo.tsx
@@ -1,4 +1,25 @@
 import React from 'react';
+import Select from 'react-select';
+
+const fruitOptions = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana' },
+  { value: 'orange', label: 'Orange' },
+];
+
 export default function PageTwo() {
-  return <div>Second page inside MFE B</div>;
+  const [selected, setSelected] = React.useState<typeof fruitOptions[number] | null>(null);
+
+  return (
+    <div>
+      <div>Second page inside MFE B</div>
+      <Select
+        options={fruitOptions}
+        value={selected}
+        onChange={(option: any) => setSelected(option)}
+        placeholder="Select a fruit"
+        isClearable
+      />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- demo fruit dropdown using `react-select` in MFE B
- add react-select dependency

## Testing
- `yarn --cwd mfe-b build` *(fails: Cannot find module 'react-select')*

------
https://chatgpt.com/codex/tasks/task_e_68c11edae1f0832fa9d5a570620de01b