### PR TITLE
Fix remote loader to properly bootstrap federated modules

### DIFF
--- a/host/src/MicroFrontend.tsx
+++ b/host/src/MicroFrontend.tsx
@@ -3,8 +3,18 @@ import React, { useEffect, useRef, useState } from "react";
 import { loadRemote } from "./utils/loadMFE";
 
 const REMOTES = {
-  mfeA: { remote: "http://localhost:3001/remoteEntry.js", exposed: "./mount", shareScope: "react18" },
-  mfeB: { remote: "http://localhost:3002/remoteEntry.js", exposed: "./mount", shareScope: "react19" },
+  mfeA: {
+    url: "http://localhost:3001/remoteEntry.js",
+    scope: "mfeA",
+    module: "./mount",
+    shareScope: "react18",
+  },
+  mfeB: {
+    url: "http://localhost:3002/remoteEntry.js",
+    scope: "mfeB",
+    module: "./mount",
+    shareScope: "react19",
+  },
 } as const;
 
 type RemoteKey = keyof typeof REMOTES;
@@ -21,8 +31,9 @@ export function MicroFrontend({ remote }: { remote: RemoteKey }) {
       try {
         const cfg = REMOTES[remote];
         const { mount } = await loadRemote<{ mount: (el: HTMLElement) => { unmount: () => void } }>({
-          remote: cfg.remote,
-          exposed: cfg.exposed,
+          url: cfg.url,
+          scope: cfg.scope,
+          module: cfg.module,
           shareScope: cfg.shareScope,
         });
 

--- a/host/src/utils/loadMFE.ts
+++ b/host/src/utils/loadMFE.ts
@@ -1,16 +1,47 @@
 type ShareScopeName = "default" | "react18" | "react19";
 
+interface LoadRemoteOptions {
+  url: string;
+  scope: string;
+  module: string;
+  shareScope?: ShareScopeName;
+}
+
 export async function loadRemote<T = any>({
-  remote,
-  exposed,
+  url,
+  scope,
+  module,
   shareScope = "default",
-}: { remote: string; exposed: string; shareScope?: ShareScopeName }): Promise<T> {
-  // @ts-ignore
+}: LoadRemoteOptions): Promise<T> {
+  // @ts-ignore: init share scope is injected by Module Federation runtime
   await __webpack_init_sharing__(shareScope);
-  // @ts-ignore
-  const container = (await (window as any)[remote]) ?? (await import(/* webpackIgnore: true */ remote));
-  // @ts-ignore
+  const container = await loadContainer(url, scope);
+  // @ts-ignore: share scopes are also injected by MF runtime
   await container.init(__webpack_share_scopes__[shareScope]);
-  const factory = await container.get(exposed);
+  const factory = await container.get(module);
   return factory();
+}
+
+function loadContainer(url: string, scope: string): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const existing = (window as any)[scope];
+    if (existing) {
+      resolve(existing);
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = url;
+    script.type = "text/javascript";
+    script.onload = () => {
+      const container = (window as any)[scope];
+      if (container) {
+        resolve(container);
+      } else {
+        reject(new Error(`Container ${scope} not found at ${url}`));
+      }
+    };
+    script.onerror = () => reject(new Error(`Failed to load remote entry ${url}`));
+    document.head.appendChild(script);
+  });
 }


### PR DESCRIPTION
## Summary
- load remoteEntry.js via script injection instead of `import`
- supply scope/module info for each remote to the loader

## Testing
- ⚠️ `yarn build` *(fails: project expects Yarn 1, installing it returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c125e86d40832f923c40e14815a7a6